### PR TITLE
Update the runtime version from 48 to 50, and more

### DIFF
--- a/com.github.tenderowl.frog.json
+++ b/com.github.tenderowl.frog.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "com.github.tenderowl.frog",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "48",
+    "runtime-version" : "50",
     "sdk" : "org.gnome.Sdk",
     "command" : "frog",
     "finish-args" : [
@@ -16,27 +16,14 @@
     ],
     "cleanup" : [
         "/include",
+        "/lib/cmake",
         "/lib/pkgconfig",
-        "/man",
         "/share/doc",
-        "/share/gtk-doc",
-        "/share/man",
-        "/share/pkgconfig",
+        "/share/gir-1.0",
         "*.la",
         "*.a"
     ],
     "modules" : [
-        {
-            "name" : "blueprint-compiler",
-            "buildsystem" : "meson",
-            "sources" : [
-                {
-                    "type" : "git",
-                    "url" : "https://gitlab.gnome.org/jwestman/blueprint-compiler.git",
-                    "tag" : "v0.16.0"
-                }
-            ]
-        },
         "leptonica.json",
         "tesseract.json",
         "libportal.json",

--- a/python3-modules.json
+++ b/python3-modules.json
@@ -18,6 +18,20 @@
             ]
         },
         {
+            "name": "python3-six",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"six\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl",
+                    "sha256": "4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"
+                }
+            ]
+        },
+        {
             "name": "python3-posthog",
             "buildsystem": "simple",
             "build-commands": [


### PR DESCRIPTION
- Update the runtime version to 50
- Add the required python3-six module
- Use the blueprint-compiler module from the runtime
- Drop ineffective cleanup commands
- Improve the cleanup commands to reduce the Flatpak size